### PR TITLE
Escape slash for proper Haddock rendering

### DIFF
--- a/haskell-brainfuck.cabal
+++ b/haskell-brainfuck.cabal
@@ -6,7 +6,7 @@ synopsis: BrainFuck interpreter
 description: BrainFuck language interpreter.
              Provides a library for evaluation and an executable to evaluate
              brainfuck files. Evaluation happens under an arbitrary monad so
-             programn can be evaluated doing I/O to stdin/stdout or in memory
+             programn can be evaluated doing I\/O to stdin\/stdout or in memory
              using the State monad.
 
 license:             MIT


### PR DESCRIPTION
Without the fix, the package description is not properly rendered by Haddock: see for instance http://paraseba.github.io/haskell-brainfuck/.
